### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/backend/nodejs/networkUtils.js
+++ b/backend/nodejs/networkUtils.js
@@ -140,7 +140,7 @@ export class NetworkScanner {
                 });
               }
             } catch (err) {
-              console.error(`Error scanning ${ip}:`, err);
+              console.error('Error scanning %s:', ip, err);
             }
             resolve();
           })


### PR DESCRIPTION
Potential fix for [https://github.com/coff33ninja/alttab/security/code-scanning/3](https://github.com/coff33ninja/alttab/security/code-scanning/3)

To fix the problem, we should ensure that the format string does not directly include unsanitized user input. Instead, we can use a `%s` specifier in the format string and pass the untrusted data as a corresponding argument. This approach will prevent any unexpected format specifiers from causing issues.

Specifically, we need to update the log message on line 143 in `backend/nodejs/networkUtils.js` to use a `%s` specifier for the `ip` value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
