### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/backend/nodejs/networkUtils.js
+++ b/backend/nodejs/networkUtils.js
@@ -126,7 +126,7 @@ export class NetworkScanner {
                   
                   if (isAnyPortOpen) break;
                 } catch (err) {
-                  console.error(`Error scanning port ${port} on ${ip}:`, err);
+                  console.error(`Error scanning port %d on %s:`, port, ip, err);
                 }
               }
 


### PR DESCRIPTION
Potential fix for [https://github.com/coff33ninja/alttab/security/code-scanning/2](https://github.com/coff33ninja/alttab/security/code-scanning/2)

To fix the problem, we need to ensure that the user-provided `ip` value is properly sanitized before being used in the format string. The best way to fix this issue without changing existing functionality is to use a `%s` specifier in the format string and pass the `ip` value as a corresponding argument. This approach ensures that the `ip` value is treated as a string, preventing any unintended format specifiers from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
