### PR TITLE
Potential fix for code scanning alert no. 31: Missing rate limiting

### DIFF
--- a/backend/nodejs/networkUtils.js
+++ b/backend/nodejs/networkUtils.js
@@ -140,7 +140,7 @@ export class NetworkScanner {
                 });
               }
             } catch (err) {
-              console.error(`Error scanning ${ip}:`, err);
+              console.error('Error scanning %s:', ip, err);
             }
             resolve();
           })

--- a/backend/nodejs/src/routes/user.routes.ts
+++ b/backend/nodejs/src/routes/user.routes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { AuthController } from '../controllers/auth.controller';
 import { authMiddleware } from '../middleware/auth.middleware';
+import rateLimit from 'express-rate-limit';
 
 const router = express.Router();
 
@@ -9,6 +10,10 @@ router.post('/register', AuthController.register);
 router.post('/login', AuthController.login);
 
 // Protected routes
-router.get('/profile', authMiddleware, AuthController.getProfile);
+const profileLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+router.get('/profile', profileLimiter, authMiddleware, AuthController.getProfile);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/coff33ninja/alttab/security/code-scanning/31](https://github.com/coff33ninja/alttab/security/code-scanning/31)

To fix the problem, we need to introduce rate limiting to the `/profile` route to prevent potential denial-of-service attacks. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `user.routes.ts` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the `/profile` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
